### PR TITLE
Expo를 추가함에 따라서 발생한 디펜던시 버전 충돌 문제 수정

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,0 +1,6 @@
+import { Slot } from 'expo-router';
+import React from 'react';
+
+export default function RootLayout() {
+  return <Slot />;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "expo-symbols": "~0.4.5",
         "expo-system-ui": "~5.0.10",
         "expo-web-browser": "~14.2.0",
-        "react": "^19.1.0",
+        "react": "19.0.0",
+        "react-dom": "19.0.0",
         "react-native": "^0.79.5",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-reanimated": "~3.17.4",
@@ -61,7 +62,7 @@
         "lint-staged": "^16.1.2",
         "prettier": "^3.6.0",
         "react-native-svg-transformer": "^1.5.1",
-        "react-test-renderer": "^19.1.0",
+        "react-test-renderer": "19.0.0",
         "typescript": "~5.8.3"
       },
       "engines": {
@@ -14486,9 +14487,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14526,16 +14527,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.25.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^19.0.0"
       }
     },
     "node_modules/react-fast-compare": {
@@ -14941,12 +14941,6 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
-    "node_modules/react-native/node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "license": "MIT"
-    },
     "node_modules/react-native/node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -14976,17 +14970,17 @@
       }
     },
     "node_modules/react-test-renderer": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
-      "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.0.0.tgz",
+      "integrity": "sha512-oX5u9rOQlHzqrE/64CNr0HB0uWxkCQmZNSfozlYvwE71TLVgeZxVf0IjouGEr1v7r1kcDifdAJBeOhdhxsG/DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "react-is": "^19.1.0",
-        "scheduler": "^0.26.0"
+        "react-is": "^19.0.0",
+        "scheduler": "^0.25.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^19.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -15421,9 +15415,9 @@
       "license": "ISC"
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "license": "MIT"
     },
     "node_modules/schema-utils": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.10",
     "expo-web-browser": "~14.2.0",
-    "react": "^19.1.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
     "react-native": "^0.79.5",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-reanimated": "~3.17.4",
@@ -64,7 +65,7 @@
     "lint-staged": "^16.1.2",
     "prettier": "^3.6.0",
     "react-native-svg-transformer": "^1.5.1",
-    "react-test-renderer": "^19.1.0",
+    "react-test-renderer": "19.0.0",
     "typescript": "~5.8.3"
   },
   "lint-staged": {


### PR DESCRIPTION
## 요약
Expo를 추가함에 따라서 발생한 디펜던시 버전 충돌 문제 수정

## 변경 사항
```
 ERROR  Error: Incompatible React versions: The "react" and "react-native-renderer" packages must have the exact same version. Instead got:
  - react:                  19.1.0
  - react-native-renderer:  19.0.0
Learn more: https://react.dev/warnings/version-mismatch, js engine: hermes
 ERROR  TypeError: Cannot read property 'default' of undefined, js engine: hermes
```

- 위 오류를 해결하기 위해서 `react-test-renderer`, `react-dom`과 `react`를 19.0.0으로 고정

```
Warning: Invalid prop style supplied to React.Fragment — no Fragment used
```
- 위 오류를 해결하기 위해서 `app/_layout.tsx` 추가