### PR TITLE
Protected Route 적용 및 로그인 시 메인으로 이동

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -28,7 +28,7 @@ function AppLayout() {
         <Stack.Screen name="myCoupon/MyCouponList" />
         <Stack.Screen name="stamp/StampList" />
         <Stack.Screen name="store/[id]" />
-        <Stack.Screen name="stamp/search" />
+        <Stack.Screen name="store/search" />
       </Stack.Protected>
 
       <Stack.Protected guard={!isAuthenticated}>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,15 +1,47 @@
-import { Slot } from 'expo-router';
 import React from 'react';
+import { Stack } from 'expo-router';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ActivityIndicator, View } from 'react-native';
+import useAuth from '../src/hooks/useAuth';
 
 const queryClient = new QueryClient();
+
+function AppLayout() {
+  const { isAuthenticated } = useAuth();
+
+  if (isAuthenticated === null) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <Stack>
+      <Stack.Protected guard={isAuthenticated}>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="giftCard/GiftCardList" options={{ headerShown: false }} />
+        <Stack.Screen name="giftCard/GiftCardPurchase" options={{ headerShown: false }} />
+        <Stack.Screen name="giftCard/GiftCardDetail/[id]" options={{ headerShown: false }} />
+        <Stack.Screen name="myCoupon/MyCouponList" options={{ headerShown: false }} />
+        <Stack.Screen name="stamp/StampList" options={{ headerShown: false }} />
+      </Stack.Protected>
+
+      <Stack.Protected guard={!isAuthenticated}>
+        <Stack.Screen name="auth/LoginChoiceScreen" options={{ headerShown: false }} />
+        <Stack.Screen name="oauth" options={{ headerShown: false }} />
+      </Stack.Protected>
+    </Stack>
+  );
+}
 
 export default function RootLayout() {
   return (
     <QueryClientProvider client={queryClient}>
       <GestureHandlerRootView style={{ flex: 1 }}>
-        <Slot />
+        <AppLayout />
       </GestureHandlerRootView>
     </QueryClientProvider>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,19 +19,21 @@ function AppLayout() {
   }
 
   return (
-    <Stack>
+    <Stack screenOptions={{ headerShown: false }}>
       <Stack.Protected guard={isAuthenticated}>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="giftCard/GiftCardList" options={{ headerShown: false }} />
-        <Stack.Screen name="giftCard/GiftCardPurchase" options={{ headerShown: false }} />
-        <Stack.Screen name="giftCard/GiftCardDetail/[id]" options={{ headerShown: false }} />
-        <Stack.Screen name="myCoupon/MyCouponList" options={{ headerShown: false }} />
-        <Stack.Screen name="stamp/StampList" options={{ headerShown: false }} />
+        <Stack.Screen name="(tabs)" />
+        <Stack.Screen name="giftCard/GiftCardList" />
+        <Stack.Screen name="giftCard/GiftCardPurchase" />
+        <Stack.Screen name="giftCard/GiftCardDetail/[id]" />
+        <Stack.Screen name="myCoupon/MyCouponList" />
+        <Stack.Screen name="stamp/StampList" />
+        <Stack.Screen name="store/[id]" />
+        <Stack.Screen name="stamp/search" />
       </Stack.Protected>
 
       <Stack.Protected guard={!isAuthenticated}>
-        <Stack.Screen name="auth/LoginChoiceScreen" options={{ headerShown: false }} />
-        <Stack.Screen name="oauth" options={{ headerShown: false }} />
+        <Stack.Screen name="auth/LoginChoiceScreen" />
+        <Stack.Screen name="oauth" />
       </Stack.Protected>
     </Stack>
   );

--- a/app/oauth.tsx
+++ b/app/oauth.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useRouter } from 'expo-router';
-import { View, ActivityIndicator } from 'react-native';
+import { ActivityIndicator, View } from 'react-native';
 import * as Keychain from 'react-native-keychain';
 
 export default function OAuthRedirectScreen() {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+import * as Keychain from 'react-native-keychain';
+
+const getAccessToken = async () => {
+  try {
+    return await Keychain.getGenericPassword({
+      service: 'com.kkukmoa.accessToken',
+    });
+  } catch (error) {
+    console.error('Failed to get access token:', error);
+    throw new Error('Failed to retrieve credentials');
+  }
+};
+
+const useAuth = () => {
+  const {
+    data: credentials,
+    isPending,
+    isError,
+  } = useQuery({
+    queryKey: ['auth', 'accessToken'],
+    queryFn: getAccessToken,
+    staleTime: Infinity,
+    retry: false, // 로컬 키체인에서 불러오기 때문에 재시도 하지 않음
+  });
+
+  if (isPending) {
+    return { isAuthenticated: null };
+  }
+
+  if (isError) {
+    return { isAuthenticated: false };
+  }
+
+  return { isAuthenticated: !!credentials };
+};
+
+export default useAuth;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -32,7 +32,7 @@ const useAuth = () => {
     return { isAuthenticated: false };
   }
 
-  return { isAuthenticated: !!credentials };
+  return { isAuthenticated: !!(credentials && credentials.password) };
 };
 
 export default useAuth;

--- a/src/screens/auth/LoginChoiceScreen.tsx
+++ b/src/screens/auth/LoginChoiceScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Image, StyleSheet, TouchableOpacity, Text } from 'react-native';
+import { useQueryClient } from '@tanstack/react-query';
 import { KkButton } from '../../design/component/KkButton';
 import colors from '../../design/colors';
 import handleKakaoLogin from '../../api/kakaoLogin';
@@ -56,7 +57,16 @@ const logoImage = require('../../assets/images/logo/LogoText2.png');
 const naverImage = require('../../assets/images/logo/naverlogo.png');
 
 export default function LoginChoiceScreen() {
-  // const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const handleKakaoLoginPress = async () => {
+    const result = await handleKakaoLogin();
+    if (result !== null) {
+      // ['auth', 'accessToken']을 invalidate 하면 useAuth()의 값이 바뀌면서 protected route로 메인 화면으로 이동하게 됨
+      await queryClient.invalidateQueries({ queryKey: ['auth', 'accessToken'] });
+    }
+  };
+
   return (
     <View style={styles.container}>
       <Image source={logoImage} style={styles.logo} resizeMode="contain" />
@@ -74,7 +84,7 @@ export default function LoginChoiceScreen() {
           type="primary"
           size="large"
           shadow
-          onPress={handleKakaoLogin}
+          onPress={handleKakaoLoginPress}
         />
 
         <KkButton label="이메일 가입" type="secondary" size="large" shadow onPress={() => {}} />

--- a/src/screens/auth/LoginChoiceScreen.tsx
+++ b/src/screens/auth/LoginChoiceScreen.tsx
@@ -63,7 +63,8 @@ export default function LoginChoiceScreen() {
     const result = await handleKakaoLogin();
     if (result !== null) {
       // ['auth', 'accessToken']을 invalidate 하면 useAuth()의 값이 바뀌면서 protected route로 메인 화면으로 이동하게 됨
-      await queryClient.invalidateQueries({ queryKey: ['auth', 'accessToken'] });
+      // noinspection ES6MissingAwait
+      queryClient.invalidateQueries({ queryKey: ['auth', 'accessToken'] });
     }
   };
 


### PR DESCRIPTION
## 요약
- 로그인 화면이 실제로 사용되고, 이에 따라 Protected Route이 적용됨

## 변경점
- Protected Route 적용
- 로그인 상태를 알 수 있는 `useAuth` 훅 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 인증 상태에 따라 화면이 분리되는 보호된 네비게이션 스택이 도입되었습니다.
  * 앱 전체에 인증 상태를 확인하는 로딩 스피너가 추가되었습니다.
  * 로컬에 저장된 인증 정보를 확인하는 새로운 인증 훅이 추가되었습니다.

* **버그 수정**
  * 카카오 로그인 후 인증 상태가 즉시 반영되어 메인 화면으로 이동합니다.

* **리팩터링**
  * 레이아웃 구조가 개선되어 인증 및 내비게이션 관리가 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->