### PR TITLE
카카오 로그인 & 토큰 재발급 & 로그아웃 API 연동 [#50][#59]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "expo-status-bar": "~2.2.3",
         "expo-symbols": "~0.4.5",
         "expo-system-ui": "~5.0.10",
+        "expo-updates": "^0.28.17",
         "expo-web-browser": "~14.2.0",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -8982,6 +8983,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.14.4.tgz",
+      "integrity": "sha512-TSL1BbBFIuXchJmPgbPnB7cGpOOuSGJcQ/L7gij/+zPjExwvKm5ckA5dlSulwoFhH8zQt4vb7bfISPSAWQVWBw==",
+      "license": "MIT"
+    },
     "node_modules/expo-file-system": {
       "version": "18.1.11",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.11.tgz",
@@ -9031,6 +9038,12 @@
         }
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "14.1.4",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-14.1.4.tgz",
@@ -9070,6 +9083,19 @@
       "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-18.1.6.tgz",
       "integrity": "sha512-l5dQQ2FYkrBgNzaZN1BvSmdhhcztFOUucu2kEfDBMV4wSIuTIt/CKsho+F3RnAiWgvui1wb1WTTf80E8zq48hA==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.16.6.tgz",
+      "integrity": "sha512-1A+do6/mLUWF9xd3uCrlXr9QFDbjbfqAYmUy8UDLOjof1lMrOhyeC4Yi6WexA/A8dhZEpIxSMCKfn7G4aHAh4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~11.0.12",
+        "expo-json-utils": "~0.15.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }
@@ -9208,6 +9234,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-structured-headers": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-4.1.0.tgz",
+      "integrity": "sha512-2X+aUNzC/qaw7/WyUhrVHNDB0uQ5rE12XA2H/rJXaAiYQSuOeU90ladaN0IJYV9I2XlhYrjXLktLXWbO7zgbag==",
+      "license": "MIT"
+    },
     "node_modules/expo-symbols": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/expo-symbols/-/expo-symbols-0.4.5.tgz",
@@ -9239,6 +9271,69 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-updates": {
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.28.17.tgz",
+      "integrity": "sha512-OiKDrKk6EoBRP9AoK7/4tyj9lVtHw2IfaETIFeUCHMgx5xjgKGX/jjSwqhk8N9BJgLDIy0oD0Sb0MaEbSBb3lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "0.0.5",
+        "@expo/config": "~11.0.13",
+        "@expo/config-plugins": "~10.1.2",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "expo-eas-client": "~0.14.4",
+        "expo-manifests": "~0.16.6",
+        "expo-structured-headers": "~4.1.0",
+        "expo-updates-interface": "~1.1.0",
+        "glob": "^10.4.2",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-1.1.0.tgz",
+      "integrity": "sha512-DeB+fRe0hUDPZhpJ4X4bFMAItatFBUPjw/TVSbJsaf3Exeami+2qbbJhWkcTMoYHOB73nOIcaYcWXYJnCJXO0w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/expo-web-browser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "expo-status-bar": "~2.2.3",
         "expo-symbols": "~0.4.5",
         "expo-system-ui": "~5.0.10",
-        "expo-updates": "^0.28.17",
+        "expo-updates": "~0.28.17",
         "expo-web-browser": "~14.2.0",
         "react": "19.0.0",
         "react-dom": "19.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.10",
+    "expo-updates": "^0.28.17",
     "expo-web-browser": "~14.2.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.10",
-    "expo-updates": "^0.28.17",
+    "expo-updates": "~0.28.17",
     "expo-web-browser": "~14.2.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -39,6 +39,7 @@ apiClient.interceptors.response.use(
   async (error) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const originalRequest = (error.config || {}) as any;
+    if (!originalRequest) return Promise.reject(error);
 
     // eslint-disable-next-line no-underscore-dangle
     if (error.response?.status === 401 && !originalRequest._retry) {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { Platform } from 'react-native';
-import { getGenericPassword, setGenericPassword } from 'react-native-keychain';
+import { getGenericPassword } from 'react-native-keychain';
 import reissueTokens from './reissueTokens';
 
 let refreshPromise: Promise<{ accessToken: string; refreshToken?: string } | null> | null = null;
@@ -56,16 +56,6 @@ apiClient.interceptors.response.use(
       if (newTokens) {
         try {
           originalRequest.headers = originalRequest.headers || {};
-
-          // Keychain 업데이트
-          await setGenericPassword('accessToken', newTokens.accessToken, {
-            service: 'com.kkukmoa.accessToken',
-          });
-          if (newTokens.refreshToken) {
-            await setGenericPassword('refreshToken', newTokens.refreshToken, {
-              service: 'com.kkukmoa.refreshToken',
-            });
-          }
           originalRequest.headers.Authorization = `Bearer ${newTokens.accessToken}`;
 
           return await apiClient(originalRequest);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { Platform } from 'react-native';
-import { getGenericPassword } from 'react-native-keychain';
+import { getGenericPassword, setGenericPassword } from 'react-native-keychain';
+import reissueTokens from './reissueTokens';
 
 const baseUrl = process.env.EXPO_PUBLIC_BASE_URL;
 if (!baseUrl) {
@@ -29,5 +30,38 @@ apiClient.interceptors.request.use(async (config) => {
 
   return newConfig;
 });
+
+// 401 Unauthorized 발생 시 토큰 재발급 후 재요청 처리
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    // eslint-disable-next-line no-underscore-dangle
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      // eslint-disable-next-line no-underscore-dangle
+      originalRequest._retry = true;
+
+      const newTokens = await reissueTokens();
+
+      if (newTokens) {
+        try {
+          await setGenericPassword('accessToken', newTokens.accessToken, {
+            service: 'com.kkukmoa.accessToken',
+          });
+
+          // 요청 헤더에 새 accessToken 설정
+          originalRequest.headers.Authorization = `Bearer ${newTokens.accessToken}`;
+
+          return await apiClient(originalRequest);
+        } catch (e) {
+          console.error('Failed to update access token in Keychain', e);
+          return Promise.reject(error);
+        }
+      }
+    }
+    return Promise.reject(error);
+  },
+);
 
 export default apiClient;

--- a/src/api/kakaoLogin.ts
+++ b/src/api/kakaoLogin.ts
@@ -1,26 +1,24 @@
 import * as WebBrowser from 'expo-web-browser';
-import * as Linking from 'expo-linking';
 import { TokenResponse } from '../types/kakao';
-import saveTokens from '../utils/tokenStorage';
+import { saveTokens } from '../utils/tokenStorage';
 
 const KAKAO_LOGIN_URL = process.env.EXPO_PUBLIC_KAKAO_LOGIN_URL;
-if (!KAKAO_LOGIN_URL) throw new Error('EXPO_PUBLIC_KAKAO_LOGIN_URL is not defined.');
+if (!KAKAO_LOGIN_URL) throw new Error('[KakaoLogin] EXPO_PUBLIC_KAKAO_LOGIN_URL is not defined.');
 
 function timeout(ms: number): Promise<never> {
   return new Promise((_, reject) => {
-    setTimeout(() => {
-      reject(new Error('TIMEOUT'));
-    }, ms);
+    setTimeout(() => reject(new Error('TIMEOUT')), ms);
   });
 }
 
 const handleKakaoLogin = async (): Promise<TokenResponse | null> => {
   try {
-    const redirectUrl = Linking.createURL('oauth');
+    const redirectUrl = 'kkukmoa://oauth';
     const loginUrl = `${KAKAO_LOGIN_URL}?redirect_uri=${encodeURIComponent(redirectUrl)}&mobile=true`;
 
     const timeoutPromise = timeout(60000);
 
+    // 카카오 로그인 창 열기
     const result = (await Promise.race([
       WebBrowser.openAuthSessionAsync(loginUrl, redirectUrl, { showInRecents: true }),
       timeoutPromise,
@@ -28,64 +26,34 @@ const handleKakaoLogin = async (): Promise<TokenResponse | null> => {
 
     if (result.type !== 'success' || !result.url) return null;
 
+    // 딥링크에서 코드 추출
     const url = new URL(result.url);
-    const encodedToken = url.searchParams.get('token');
-    const error = url.searchParams.get('error');
-    if (error || !encodedToken) return null;
+    const exchangeCode = url.searchParams.get('code');
+    if (!exchangeCode) return null;
 
-    let tokenData;
-    // 토큰 디코딩
-    try {
-      // JWT인 경우
-      if (encodedToken.includes('.')) {
-        const payload = encodedToken.split('.')[1];
-        const decodedPayload = Buffer.from(
-          payload.replace(/-/g, '+').replace(/_/g, '/'),
-          'base64',
-        ).toString();
-        const jwtData = JSON.parse(decodedPayload);
-        tokenData = {
-          accessToken: encodedToken,
-          refreshToken: encodedToken,
-          userId: jwtData.sub || jwtData.user_id,
-          email: jwtData.email || jwtData.sub,
-          newUser: false,
-        };
-      } else {
-        // Base64로 인코딩된 JSON인 경우
-        const decodedString = Buffer.from(encodedToken, 'base64').toString();
-        tokenData = JSON.parse(decodedString);
-      }
-    } catch {
-      // 디코딩 실패 시 원본 토큰 사용
-      tokenData = {
-        accessToken: encodedToken,
-        refreshToken: encodedToken,
-        userId: null,
-        email: null,
-        newUser: false,
-      };
-    }
+    // 교환 코드로 토큰 발급 요청
+    const tokenRes = await fetch(
+      `https://kkukmoa.shop/v1/users/exchange?code=${encodeURIComponent(exchangeCode)}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
 
-    const { accessToken, refreshToken, userId, email, newUser } = tokenData;
-    if (!accessToken) return null;
+    if (!tokenRes.ok) return null;
 
-    await saveTokens(accessToken, refreshToken || accessToken);
+    const { accessToken, refreshToken } = await tokenRes.json();
+    if (!accessToken || !refreshToken) return null;
+
+    await saveTokens(accessToken, refreshToken);
 
     return {
-      id: userId ? parseInt(userId, 10) : 0,
-      tokenResponseDto: { accessToken, refreshToken: refreshToken || accessToken },
-      email: email || '',
-      newUser: Boolean(newUser),
+      id: 0,
+      tokenResponseDto: { accessToken, refreshToken },
+      email: '',
+      newUser: false,
     };
-  } catch (error) {
-    if (error instanceof Error) {
-      if (error.message === 'TIMEOUT') {
-        console.warn('로그인 시간이 초과되었습니다.');
-      } else {
-        console.error('카카오 로그인 실패:', error);
-      }
-    }
+  } catch {
     return null;
   }
 };

--- a/src/api/kakaoLogin.ts
+++ b/src/api/kakaoLogin.ts
@@ -1,4 +1,5 @@
 import * as WebBrowser from 'expo-web-browser';
+import * as Linking from 'expo-linking';
 import axios from 'axios';
 import { TokenResponse } from '../types/kakao';
 import { saveTokens } from '../utils/tokenStorage';
@@ -14,7 +15,7 @@ function timeout(ms: number): Promise<never> {
 
 const handleKakaoLogin = async (): Promise<TokenResponse | null> => {
   try {
-    const redirectUrl = 'kkukmoa://oauth';
+    const redirectUrl = Linking.createURL('oauth');
     const loginUrl = `${KAKAO_LOGIN_URL}?redirect_uri=${encodeURIComponent(redirectUrl)}&mobile=true`;
 
     const timeoutPromise = timeout(60000);

--- a/src/api/logout.ts
+++ b/src/api/logout.ts
@@ -1,0 +1,38 @@
+import * as Keychain from 'react-native-keychain';
+import apiClient from './client';
+import { getAccessToken, getRefreshToken } from '../utils/tokenStorage';
+
+const logout = async () => {
+  try {
+    const accessToken = await getAccessToken();
+    const refreshToken = await getRefreshToken();
+
+    if (!accessToken || !refreshToken) {
+      console.warn('토큰이 없습니다.');
+      return;
+    }
+
+    const response = await apiClient.post('/v1/users/logout', null, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'refresh-token': refreshToken,
+      },
+    });
+
+    console.log('로그아웃 성공:', response.data);
+
+    // 토큰 삭제
+    await Keychain.resetGenericPassword({ service: 'com.kkukmoa.accessToken' });
+    await Keychain.resetGenericPassword({ service: 'com.kkukmoa.refreshToken' });
+  } catch (error: any) {
+    if (error.response) {
+      console.error('로그아웃 실패 status:', error.response.status);
+      console.error('로그아웃 실패 data:', error.response.data);
+    } else {
+      console.error('로그아웃 실패:', error);
+    }
+    throw error;
+  }
+};
+
+export default logout;

--- a/src/api/reissueTokens.ts
+++ b/src/api/reissueTokens.ts
@@ -23,8 +23,13 @@ const reissueTokens = async () => {
     await saveTokens(accessToken, newRefreshToken);
 
     return { accessToken, refreshToken: newRefreshToken };
-  } catch (error) {
-    console.error('토큰 재발급 실패:', error);
+  } catch (error: unknown) {
+    if (typeof error === 'object' && error && 'isAxiosError' in (error as any)) {
+      const err = error as import('axios').AxiosError<any>;
+      console.error('토큰 재발급 실패 status:', err.response?.status, 'message:', err.message);
+    } else {
+      console.error('토큰 재발급 실패:', (error as Error)?.message ?? error);
+    }
     return null;
   }
 };

--- a/src/api/reissueTokens.ts
+++ b/src/api/reissueTokens.ts
@@ -1,20 +1,16 @@
-import * as Keychain from 'react-native-keychain';
 import axios from 'axios';
-import { saveTokens } from '../utils/tokenStorage';
+import { getRefreshToken, saveTokens } from '../utils/tokenStorage';
 
 const baseUrl = process.env.EXPO_PUBLIC_BASE_URL;
 if (!baseUrl) throw new Error('EXPO_PUBLIC_BASE_URL is not defined.');
 
 const reissueTokens = async () => {
   try {
-    const refreshTokenCreds = await Keychain.getGenericPassword({
-      service: 'com.kkukmoa.refreshToken',
-    });
-    if (!refreshTokenCreds) {
+    const refreshToken = await getRefreshToken();
+    if (!refreshToken) {
       console.warn('No refresh token found');
       return null;
     }
-    const refreshToken = refreshTokenCreds.password;
 
     const { data } = await axios.post(
       `${baseUrl}/v1/users/reissue`,

--- a/src/api/reissueTokens.ts
+++ b/src/api/reissueTokens.ts
@@ -1,22 +1,23 @@
 import * as Keychain from 'react-native-keychain';
-import apiClient from './client';
+import axios from 'axios';
 import { saveTokens } from '../utils/tokenStorage';
+
+const baseUrl = process.env.EXPO_PUBLIC_BASE_URL;
+if (!baseUrl) throw new Error('EXPO_PUBLIC_BASE_URL is not defined.');
 
 const reissueTokens = async () => {
   try {
     const refreshTokenCreds = await Keychain.getGenericPassword({
       service: 'com.kkukmoa.refreshToken',
     });
-
     if (!refreshTokenCreds) {
       console.warn('No refresh token found');
       return null;
     }
-
     const refreshToken = refreshTokenCreds.password;
 
-    const { data } = await apiClient.post(
-      '/v1/users/reissue',
+    const { data } = await axios.post(
+      `${baseUrl}/v1/users/reissue`,
       {},
       { headers: { Authorization: `Bearer ${refreshToken}` } },
     );

--- a/src/api/reissueTokens.ts
+++ b/src/api/reissueTokens.ts
@@ -1,0 +1,35 @@
+import * as Keychain from 'react-native-keychain';
+import apiClient from './client';
+import { saveTokens } from '../utils/tokenStorage';
+
+const reissueTokens = async () => {
+  try {
+    const refreshTokenCreds = await Keychain.getGenericPassword({
+      service: 'com.kkukmoa.refreshToken',
+    });
+
+    if (!refreshTokenCreds) {
+      console.warn('No refresh token found');
+      return null;
+    }
+
+    const refreshToken = refreshTokenCreds.password;
+
+    const { data } = await apiClient.post(
+      '/v1/users/reissue',
+      {},
+      { headers: { Authorization: `Bearer ${refreshToken}` } },
+    );
+
+    const { accessToken, refreshToken: newRefreshToken } = data;
+
+    await saveTokens(accessToken, newRefreshToken);
+
+    return { accessToken, refreshToken: newRefreshToken };
+  } catch (error) {
+    console.error('토큰 재발급 실패:', error);
+    return null;
+  }
+};
+
+export default reissueTokens;

--- a/src/screens/auth/LoginChoiceScreen.tsx
+++ b/src/screens/auth/LoginChoiceScreen.tsx
@@ -4,7 +4,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { KkButton } from '../../design/component/KkButton';
 import colors from '../../design/colors';
 import handleKakaoLogin from '../../api/kakaoLogin';
-// import { useRouter } from 'expo-router';
 
 const styles = StyleSheet.create({
   container: {

--- a/src/screens/mypage/MyPageScreen.tsx
+++ b/src/screens/mypage/MyPageScreen.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'expo-router';
 import Header from '../../design/component/Header';
 import colors from '../../design/colors';
 import ChevronRightIcon from '../../assets/images/chevron-right.svg';
+import logout from '../../api/logout';
 
 const styles = StyleSheet.create({
   container: {
@@ -66,6 +67,14 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 export default function MyPageScreen() {
   const router = useRouter();
 
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } catch (error) {
+      console.error('로그아웃 중 에러:', error);
+    }
+  };
+
   return (
     <View>
       <Header title="마이페이지" onBackPress={() => {}} />
@@ -80,7 +89,7 @@ export default function MyPageScreen() {
         <Section title="계정 관리">
           <SectionLabel label="비밀번호 재설정" onClick={() => {}} />
           <SectionLabel label="사장님 로그인 (회원가입)" onClick={() => {}} />
-          <SectionLabel label="로그아웃" onClick={() => {}} />
+          <SectionLabel label="로그아웃" onClick={handleLogout} />
         </Section>
       </View>
     </View>

--- a/src/screens/mypage/MyPageScreen.tsx
+++ b/src/screens/mypage/MyPageScreen.tsx
@@ -44,7 +44,7 @@ function SectionHeader({ title }: { title: string }) {
   return <Text style={styles.header}>{title}</Text>;
 }
 
-function SectionLabel({ label, onClick }: { label: string; onClick: () => void }) {
+function SectionLabel({ label, onClick }: { label: string; onClick: () => void | Promise<void> }) {
   return (
     <TouchableOpacity onPress={onClick}>
       <View style={styles.label}>

--- a/src/screens/mypage/MyPageScreen.tsx
+++ b/src/screens/mypage/MyPageScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
 import Header from '../../design/component/Header';
@@ -79,8 +79,9 @@ export default function MyPageScreen() {
       router.replace('/auth/LoginChoiceScreen');
     } catch (error) {
       console.error('로그아웃 중 에러:', error);
-      Alert.alert('로그아웃 실패', '네트워크 상태를 확인해주세요.');
     } finally {
+      await queryClient.invalidateQueries({ queryKey: ['auth'] });
+      router.replace('/auth/LoginChoiceScreen');
       setIsLoggingOut(false);
     }
   };

--- a/src/screens/mypage/MyPageScreen.tsx
+++ b/src/screens/mypage/MyPageScreen.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useRouter } from 'expo-router';
+import { useQueryClient } from '@tanstack/react-query';
 import Header from '../../design/component/Header';
 import colors from '../../design/colors';
 import ChevronRightIcon from '../../assets/images/chevron-right.svg';
@@ -66,10 +67,13 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 export default function MyPageScreen() {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const handleLogout = async () => {
     try {
       await logout();
+      await queryClient.clear();
+      router.replace('/auth/LoginChoiceScreen');
     } catch (error) {
       console.error('로그아웃 중 에러:', error);
     }

--- a/src/screens/mypage/MyPageScreen.tsx
+++ b/src/screens/mypage/MyPageScreen.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React, { useState } from 'react';
+import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
 import Header from '../../design/component/Header';
@@ -68,14 +68,20 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 export default function MyPageScreen() {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
 
   const handleLogout = async () => {
+    if (isLoggingOut) return;
+    setIsLoggingOut(true);
     try {
       await logout();
-      await queryClient.invalidateQueries({ queryKey: ['auth', 'accessToken'] });
+      await queryClient.invalidateQueries({ queryKey: ['auth'] });
       router.replace('/auth/LoginChoiceScreen');
     } catch (error) {
       console.error('로그아웃 중 에러:', error);
+      Alert.alert('로그아웃 실패', '네트워크 상태를 확인해주세요.');
+    } finally {
+      setIsLoggingOut(false);
     }
   };
 

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -14,16 +14,22 @@ export const saveTokens = async (accessToken: string, refreshToken: string) => {
   }
 };
 
-export const getAccessToken = async () => {
-  const creds = await Keychain.getGenericPassword({
-    service: 'com.kkukmoa.accessToken',
-  });
-  return creds ? creds.password : null;
+export const getAccessToken = async (): Promise<string | null> => {
+  try {
+    const creds = await Keychain.getGenericPassword({ service: 'com.kkukmoa.accessToken' });
+    return creds ? creds.password : null;
+  } catch (error) {
+    console.error('Failed to get access token:', error);
+    return null;
+  }
 };
 
-export const getRefreshToken = async () => {
-  const creds = await Keychain.getGenericPassword({
-    service: 'com.kkukmoa.refreshToken',
-  });
-  return creds ? creds.password : null;
+export const getRefreshToken = async (): Promise<string | null> => {
+  try {
+    const creds = await Keychain.getGenericPassword({ service: 'com.kkukmoa.refreshToken' });
+    return creds ? creds.password : null;
+  } catch (error) {
+    console.error('Failed to get refresh token:', error);
+    return null;
+  }
 };

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -1,6 +1,6 @@
 import * as Keychain from 'react-native-keychain';
 
-const saveTokens = async (accessToken: string, refreshToken: string) => {
+export const saveTokens = async (accessToken: string, refreshToken: string) => {
   try {
     await Keychain.setGenericPassword('accessToken', accessToken, {
       service: 'com.kkukmoa.accessToken',
@@ -14,4 +14,16 @@ const saveTokens = async (accessToken: string, refreshToken: string) => {
   }
 };
 
-export default saveTokens;
+export const getAccessToken = async () => {
+  const creds = await Keychain.getGenericPassword({
+    service: 'com.kkukmoa.accessToken',
+  });
+  return creds ? creds.password : null;
+};
+
+export const getRefreshToken = async () => {
+  const creds = await Keychain.getGenericPassword({
+    service: 'com.kkukmoa.refreshToken',
+  });
+  return creds ? creds.password : null;
+};


### PR DESCRIPTION
## 🔨 작업 내용
* 카카오 로그인 토큰 전달 방식 변경으로 인한 api 재연동
* 로그아웃 api 연동
* 토큰 재발급 api 연동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지에서 로그아웃 기능이 추가되었습니다.
  * 자동 토큰 갱신 및 인증 실패 시 재시도 기능이 도입되었습니다.

* **버그 수정**
  * 카카오 로그인 플로우가 백엔드 기반 토큰 교환 방식으로 개선되었습니다.

* **기타**
  * 토큰 저장 및 조회 유틸리티 함수가 추가되었습니다.
  * 로그아웃 및 토큰 재발급 관련 API가 도입되었습니다.
  * 의존성에 expo-updates 패키지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->