### PR TITLE
메인 가게 카드 리스트 API 연동 [#66]

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -54,7 +54,7 @@ function IconWrapper({ isSelected, children }: { isSelected: boolean; children: 
 export default function Layout() {
   const pathname = usePathname();
   const insets = useSafeAreaInsets();
-  const isStoreTab = pathname === '/stores';
+  const isStoreTab = pathname === '/stores' || pathname === '/';
 
   return (
     <SafeAreaView

--- a/src/screens/main/MainScreen.style.ts
+++ b/src/screens/main/MainScreen.style.ts
@@ -88,4 +88,9 @@ export default StyleSheet.create({
   cardContainer: {
     paddingHorizontal: 16,
   },
+  loading: {
+    alignItems: 'center',
+    paddingBottom: '50%',
+    color: colors.light.main,
+  },
 });

--- a/src/screens/main/MainScreen.style.ts
+++ b/src/screens/main/MainScreen.style.ts
@@ -22,7 +22,7 @@ export default StyleSheet.create({
     margin: 7,
   },
   location: {
-    fontSize: 16,
+    fontSize: 17,
     fontFamily: 'Pretendard-Bold',
     color: colors.light.white,
   },

--- a/src/screens/main/MainScreen.style.ts
+++ b/src/screens/main/MainScreen.style.ts
@@ -80,13 +80,12 @@ export default StyleSheet.create({
     fontSize: 14,
   },
   banner: {
-    borderRadius: 12,
+    justifyContent: 'center',
     alignItems: 'center',
     flex: 1,
-    paddingHorizontal: 16,
+    marginBottom: 16,
   },
   cardContainer: {
-    paddingTop: 16,
     paddingHorizontal: 16,
   },
 });

--- a/src/screens/main/MainScreen.style.ts
+++ b/src/screens/main/MainScreen.style.ts
@@ -23,7 +23,7 @@ export default StyleSheet.create({
   },
   location: {
     fontSize: 16,
-    fontWeight: '700',
+    fontFamily: 'Pretendard-Bold',
     color: colors.light.white,
   },
   rightIcons: {
@@ -78,6 +78,7 @@ export default StyleSheet.create({
     flex: 1,
     color: colors.light.gray2,
     fontSize: 14,
+    fontFamily: 'Pretendard-Medium',
   },
   banner: {
     justifyContent: 'center',

--- a/src/screens/main/MainScreen.style.ts
+++ b/src/screens/main/MainScreen.style.ts
@@ -1,7 +1,7 @@
 import { StyleSheet, Platform, StatusBar } from 'react-native';
 import colors from '../../design/colors';
 
-const STATUSBAR_HEIGHT = Platform.OS === 'android' ? (StatusBar.currentHeight ?? 0) : 44;
+const STATUSBAR_HEIGHT = Platform.OS === 'android' ? (StatusBar.currentHeight ?? 0) : 0;
 
 export default StyleSheet.create({
   container: {

--- a/src/screens/main/MainScreen.style.ts
+++ b/src/screens/main/MainScreen.style.ts
@@ -1,5 +1,7 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform, StatusBar } from 'react-native';
 import colors from '../../design/colors';
+
+const STATUSBAR_HEIGHT = Platform.OS === 'android' ? (StatusBar.currentHeight ?? 0) : 44;
 
 export default StyleSheet.create({
   container: {
@@ -8,7 +10,7 @@ export default StyleSheet.create({
   },
   headerContainer: {
     backgroundColor: colors.light.main,
-    paddingTop: 25,
+    paddingTop: STATUSBAR_HEIGHT,
     paddingBottom: 0,
     paddingHorizontal: 20,
   },
@@ -38,14 +40,13 @@ export default StyleSheet.create({
   },
   searchRow: {
     flexDirection: 'row',
-    paddingHorizontal: 10,
+    paddingHorizontal: 16,
     marginBottom: 20,
     marginTop: 10,
   },
   buttonGroup: {
     flexDirection: 'row',
     gap: 8,
-    marginLeft: 10,
   },
   iconButton: {
     borderWidth: 1,
@@ -70,8 +71,8 @@ export default StyleSheet.create({
     borderRadius: 30,
     paddingHorizontal: 16,
     marginLeft: 10,
-    width: 210,
     height: 55,
+    flex: 1,
   },
   searchPlaceholder: {
     flex: 1,
@@ -79,15 +80,13 @@ export default StyleSheet.create({
     fontSize: 14,
   },
   banner: {
-    marginBottom: 20,
     borderRadius: 12,
     alignItems: 'center',
-  },
-  cardList: {
     flex: 1,
+    paddingHorizontal: 16,
   },
   cardContainer: {
-    paddingHorizontal: 18,
-    paddingBottom: 120,
+    paddingTop: 16,
+    paddingHorizontal: 16,
   },
 });

--- a/src/screens/main/MainScreen.tsx
+++ b/src/screens/main/MainScreen.tsx
@@ -1,6 +1,16 @@
-import React, { useState, useCallback } from 'react';
-import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
+import React, { useState, useCallback, useEffect } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  FlatList,
+  ActivityIndicator,
+  ScrollView,
+} from 'react-native';
 import { useRouter } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
+import { getStoreList } from '../../api/store';
+import { getAddressFromCoords, getCurrentCoords } from '../../utils/location';
 import styles from './MainScreen.style';
 import StoreCard from '../Store/StoreCard/StoreCard';
 import HeartIcon from '../../assets/images/Vector.svg';
@@ -10,115 +20,61 @@ import MapPinIcon from '../../assets/images/map-pin2.svg';
 import QRIcon from '../../assets/images/maximize.svg';
 import StampIcon from '../../assets/images/star.svg';
 import SearchBarIcon from '../../assets/images/search-icon.svg';
-import QRcodeIcon from '../../assets/images/Group.svg';
-
-// 더미데이터 (10)
-const mockStores = [
-  {
-    id: '1',
-    name: '꾹모아모아카페 성신여대입구점',
-    imageUrl: 'https://picsum.photos/200/140?1',
-    category: '카페',
-    distance: '2.16 km',
-    time: '09:00 ~ 21:00',
-    reviewCount: 21,
-    bookmarkCount: 39,
-  },
-  {
-    id: '2',
-    name: '달콤한디저트카페 강남역점',
-    imageUrl: 'https://picsum.photos/200/140?2',
-    category: '카페',
-    distance: '1.05 km',
-    time: '10:00 ~ 22:00',
-    reviewCount: 10,
-    bookmarkCount: 15,
-  },
-  {
-    id: '3',
-    name: '혼커피 홍대점',
-    imageUrl: 'https://picsum.photos/200/140?3',
-    category: '카페',
-    distance: '0.87 km',
-    time: '08:00 ~ 20:00',
-    reviewCount: 45,
-    bookmarkCount: 67,
-  },
-  {
-    id: '4',
-    name: '브레드마루 신촌본점',
-    imageUrl: 'https://picsum.photos/200/140?4',
-    category: '운동/건강',
-    distance: '3.42 km',
-    time: '07:30 ~ 19:00',
-    reviewCount: 34,
-    bookmarkCount: 22,
-  },
-  {
-    id: '5',
-    name: '모모티하우스 이태원점',
-    imageUrl: 'https://picsum.photos/200/140?5',
-    category: '음식점',
-    distance: '5.11 km',
-    time: '11:00 ~ 23:00',
-    reviewCount: 18,
-    bookmarkCount: 12,
-  },
-  {
-    id: '6',
-    name: '헬시핏짐 강남점',
-    imageUrl: 'https://picsum.photos/200/140?6',
-    category: '운동/건강',
-    distance: '2.45 km',
-    time: '06:00 ~ 23:00',
-    reviewCount: 50,
-    bookmarkCount: 40,
-  },
-  {
-    id: '7',
-    name: '헤어클래식 명동점',
-    imageUrl: 'https://picsum.photos/200/140?7',
-    category: '미용',
-    distance: '1.95 km',
-    time: '10:00 ~ 20:00',
-    reviewCount: 12,
-    bookmarkCount: 9,
-  },
-  {
-    id: '8',
-    name: '스터디팩토리 건대점',
-    imageUrl: 'https://picsum.photos/200/140?8',
-    category: '교육',
-    distance: '0.74 km',
-    time: '08:00 ~ 22:00',
-    reviewCount: 27,
-    bookmarkCount: 18,
-  },
-  {
-    id: '9',
-    name: '에그버거 서초점',
-    imageUrl: 'https://picsum.photos/200/140?9',
-    category: '음식점',
-    distance: '3.22 km',
-    time: '11:00 ~ 21:30',
-    reviewCount: 30,
-    bookmarkCount: 21,
-  },
-  {
-    id: '10',
-    name: '루프탑카페 이화여대점',
-    imageUrl: 'https://picsum.photos/200/140?10',
-    category: '카페',
-    distance: '1.11 km',
-    time: '09:30 ~ 22:00',
-    reviewCount: 16,
-    bookmarkCount: 25,
-  },
-];
+import { StoreListPage } from '../../types/store';
 
 function MainScreen() {
+  const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null);
   const [likedMap, setLikedMap] = useState<Record<string, boolean>>({});
   const router = useRouter();
+
+  const { data: location } = useQuery({
+    queryKey: ['currentCoords'],
+    queryFn: getCurrentCoords,
+  });
+
+  const { data: address, isPending: isAddrLoading } = useQuery({
+    queryKey: ['address', coords?.lat, coords?.lng],
+    queryFn: () => getAddressFromCoords(coords!.lat, coords!.lng),
+    enabled: !!coords,
+    staleTime: 60_000,
+  });
+
+  useEffect(() => {
+    if (location) {
+      setCoords(location);
+    }
+  }, [location]);
+
+  const emptyStoreListPage: StoreListPage = {
+    stores: [],
+    page: 0,
+    totalPages: 0,
+    totalElements: 0,
+    isFirst: true,
+    isLast: true,
+  };
+
+  const {
+    data: storeList = emptyStoreListPage,
+    isLoading,
+    isError,
+  } = useQuery<StoreListPage>({
+    queryKey: ['storeList', coords?.lat, coords?.lng],
+    enabled: !!coords,
+    queryFn: () =>
+      coords ? getStoreList(coords.lat, coords.lng, 0, 10) : Promise.resolve(emptyStoreListPage),
+  });
+
+  const transformedStoreList = storeList.stores.map((store) => ({
+    storeId: store.storeId.toString(),
+    name: store.name,
+    imageUrl: store.storeImage,
+    categoryName: store.categoryName,
+    distance: `${store.distance.toFixed(2)} km`,
+    time: `${store.openingHours} ~ ${store.closingHours}`,
+    reviewCount: store.reviewCount,
+    bookmarkCount: 0,
+  }));
 
   const toggleLike = useCallback((id: string) => {
     setLikedMap((prev) => ({
@@ -134,12 +90,11 @@ function MainScreen() {
         <View style={styles.topBar}>
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
             <MapPinIcon width={24} height={24} />
-            <Text style={styles.location}>용인시 기흥구 신갈동</Text>
+            <Text style={styles.location}>
+              {!coords || isAddrLoading ? '위치 불러오는 중...' : (address ?? '주소 미확인')}
+            </Text>
           </View>
           <View style={styles.rightIcons}>
-            <TouchableOpacity>
-              <QRcodeIcon width={24} height={24} />
-            </TouchableOpacity>
             <TouchableOpacity>
               <HeartIcon width={24} height={24} />
             </TouchableOpacity>
@@ -166,7 +121,7 @@ function MainScreen() {
           <View style={styles.searchBarContainer}>
             <TouchableOpacity
               style={styles.searchTouchable}
-              onPress={() => router.push('/search')}
+              onPress={() => router.push('/store/search')}
               activeOpacity={0.8}
             >
               <Text style={styles.searchPlaceholder}>매장을 검색해보세요.</Text>
@@ -175,22 +130,29 @@ function MainScreen() {
           </View>
         </View>
 
-        <ScrollView showsVerticalScrollIndicator={false} style={styles.cardList}>
-          {/* 배너 (추후 컴포넌트 만들기) */}
+        <ScrollView>
           <View style={styles.banner}>
-            <BannerImage width="92%" height={130} />
+            <BannerImage width="100%" height={130} />
           </View>
+
+          {isLoading && (
+            <ActivityIndicator style={{ alignItems: 'center', paddingBottom: '50%' }} />
+          )}
+          {isError && <Text style={{ textAlign: 'center', paddingBottom: '50%' }}>Error</Text>}
 
           {/* 가게 카드 리스트 */}
           <View style={styles.cardContainer}>
-            {mockStores.map((item) => (
-              <StoreCard
-                key={item.id}
-                item={item}
-                isLiked={likedMap[item.id] === true}
-                onToggleLike={toggleLike}
-              />
-            ))}
+            <FlatList
+              data={transformedStoreList}
+              keyExtractor={(item) => item.storeId}
+              renderItem={({ item }) => (
+                <StoreCard
+                  item={item}
+                  isLiked={likedMap[item.storeId] === true}
+                  onToggleLike={() => toggleLike(item.storeId)}
+                />
+              )}
+            />
           </View>
         </ScrollView>
       </View>

--- a/src/screens/main/MainScreen.tsx
+++ b/src/screens/main/MainScreen.tsx
@@ -72,16 +72,19 @@ function MainScreen() {
 
   const transformedStoreList = React.useMemo(
     () =>
-      storeList.stores.map((store) => ({
-        storeId: store.storeId.toString(),
-        name: store.name,
-        imageUrl: store.storeImage,
-        categoryName: store.categoryName,
-        distance: `${store.distance.toFixed(2)} km`,
-        time: `${store.openingHours} ~ ${store.closingHours}`,
-        reviewCount: store.reviewCount,
-        bookmarkCount: 0,
-      })),
+      storeList.stores.map((store) => {
+        const km = Number(store.distance);
+        return {
+          storeId: store.storeId.toString(),
+          name: store.name,
+          imageUrl: store.storeImage,
+          categoryName: store.categoryName,
+          distance: `${Number.isNaN(km) ? '0.00' : km.toFixed(2)} km`,
+          time: `${store.openingHours} ~ ${store.closingHours}`,
+          reviewCount: store.reviewCount,
+          bookmarkCount: 0,
+        };
+      }),
     [storeList.stores],
   );
 

--- a/src/screens/main/MainScreen.tsx
+++ b/src/screens/main/MainScreen.tsx
@@ -1,12 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  FlatList,
-  ActivityIndicator,
-  ScrollView,
-} from 'react-native';
+import { View, Text, TouchableOpacity, FlatList, ActivityIndicator } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
 import { getStoreList } from '../../api/store';
@@ -21,6 +14,18 @@ import QRIcon from '../../assets/images/maximize.svg';
 import StampIcon from '../../assets/images/star.svg';
 import SearchBarIcon from '../../assets/images/search-icon.svg';
 import { StoreListPage } from '../../types/store';
+
+function StoreListHeader({ isLoading, isError }: { isLoading: boolean; isError: boolean }) {
+  return (
+    <>
+      <View style={styles.banner}>
+        <BannerImage width="100%" height={130} />
+      </View>
+      {isLoading && <ActivityIndicator style={{ alignItems: 'center', paddingBottom: '50%' }} />}
+      {isError && <Text style={{ textAlign: 'center', paddingBottom: '50%' }}>Error</Text>}
+    </>
+  );
+}
 
 function MainScreen() {
   const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null);
@@ -130,31 +135,19 @@ function MainScreen() {
           </View>
         </View>
 
-        <ScrollView>
-          <View style={styles.banner}>
-            <BannerImage width="100%" height={130} />
-          </View>
-
-          {isLoading && (
-            <ActivityIndicator style={{ alignItems: 'center', paddingBottom: '50%' }} />
-          )}
-          {isError && <Text style={{ textAlign: 'center', paddingBottom: '50%' }}>Error</Text>}
-
-          {/* 가게 카드 리스트 */}
-          <View style={styles.cardContainer}>
-            <FlatList
-              data={transformedStoreList}
-              keyExtractor={(item) => item.storeId}
-              renderItem={({ item }) => (
-                <StoreCard
-                  item={item}
-                  isLiked={likedMap[item.storeId] === true}
-                  onToggleLike={() => toggleLike(item.storeId)}
-                />
-              )}
+        <FlatList
+          data={transformedStoreList}
+          keyExtractor={(item) => item.storeId}
+          ListHeaderComponent={<StoreListHeader isLoading={isLoading} isError={isError} />}
+          renderItem={({ item }) => (
+            <StoreCard
+              item={item}
+              isLiked={likedMap[item.storeId] === true}
+              onToggleLike={() => toggleLike(item.storeId)}
             />
-          </View>
-        </ScrollView>
+          )}
+          contentContainerStyle={styles.cardContainer}
+        />
       </View>
     </View>
   );

--- a/src/screens/main/MainScreen.tsx
+++ b/src/screens/main/MainScreen.tsx
@@ -21,7 +21,7 @@ function StoreListHeader({ isLoading, isError }: { isLoading: boolean; isError: 
       <View style={styles.banner}>
         <BannerImage width="100%" height={130} />
       </View>
-      {isLoading && <ActivityIndicator style={{ alignItems: 'center', paddingBottom: '50%' }} />}
+      {isLoading && <ActivityIndicator style={styles.loading} />}
       {isError && <Text style={{ textAlign: 'center', paddingBottom: '50%' }}>Error</Text>}
     </>
   );

--- a/src/screens/main/MainScreen.tsx
+++ b/src/screens/main/MainScreen.tsx
@@ -70,16 +70,20 @@ function MainScreen() {
       coords ? getStoreList(coords.lat, coords.lng, 0, 10) : Promise.resolve(emptyStoreListPage),
   });
 
-  const transformedStoreList = storeList.stores.map((store) => ({
-    storeId: store.storeId.toString(),
-    name: store.name,
-    imageUrl: store.storeImage,
-    categoryName: store.categoryName,
-    distance: `${store.distance.toFixed(2)} km`,
-    time: `${store.openingHours} ~ ${store.closingHours}`,
-    reviewCount: store.reviewCount,
-    bookmarkCount: 0,
-  }));
+  const transformedStoreList = React.useMemo(
+    () =>
+      storeList.stores.map((store) => ({
+        storeId: store.storeId.toString(),
+        name: store.name,
+        imageUrl: store.storeImage,
+        categoryName: store.categoryName,
+        distance: `${store.distance.toFixed(2)} km`,
+        time: `${store.openingHours} ~ ${store.closingHours}`,
+        reviewCount: store.reviewCount,
+        bookmarkCount: 0,
+      })),
+    [storeList.stores],
+  );
 
   const toggleLike = useCallback((id: string) => {
     setLikedMap((prev) => ({


### PR DESCRIPTION
## 🔨 작업 내용
* 메인 가게 카드 리스트 api 연동

## 📸 스크린샷
<img width="216" height="484" alt="Screenshot_1754989261" src="https://github.com/user-attachments/assets/31401343-7b34-470b-85cf-1fd01f47a66b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 현재 위치 기반으로 실제 매장 목록을 불러와 무한 로딩(페이징)으로 FlatList에 렌더링하고, 상단에 동적 주소(로딩/오류 상태 포함)를 표시합니다.
  * 검색 진입 경로를 /store/search로 통일하고, 매장 카드에 거리(소수점 2자리), 영업시간, 리뷰/북마크 정보 등 UI 친화적 항목을 추가했습니다.

* **Style**
  * 홈('/')과 스토어('/stores')의 상단 안전영역 패딩을 동일하게(0) 적용했습니다.
  * 헤더, 배너, 카드, 버튼 및 검색 영역의 여백·정렬·폰트 등 레이아웃을 유연하게 조정해 화면 적응성과 가독성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->