### PR TITLE
roles 추가된 카카오 로그인 api 연동 [#86]

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { TabList, Tabs, TabSlot, TabTrigger } from 'expo-router/ui';
 import { StatusBar, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -9,6 +9,7 @@ import HomeIcon from '../../src/assets/images/home.svg';
 import StoresIcon from '../../src/assets/images/mapicon.svg';
 import ProfileIcon from '../../src/assets/images/user.svg';
 import colors from '../../src/design/colors';
+import useAuthStore from '../../src/store/useAuthStore';
 
 const styles = StyleSheet.create({
   tabLayout: {
@@ -55,6 +56,12 @@ export default function Layout() {
   const pathname = usePathname();
   const insets = useSafeAreaInsets();
   const isStoreTab = pathname === '/stores' || pathname === '/';
+
+  const loadRoles = useAuthStore((state) => state.loadRoles);
+
+  useEffect(() => {
+    loadRoles();
+  }, []);
 
   return (
     <SafeAreaView

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,8 @@
         "react-native-vector-icons": "^10.3.0",
         "react-native-web": "~0.20.0",
         "react-native-webview": "13.13.5",
-        "react-navigation": "^5.0.0"
+        "react-navigation": "^5.0.0",
+        "zustand": "^5.0.7"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -15953,6 +15954,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.7.tgz",
+      "integrity": "sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "react-native-vector-icons": "^10.3.0",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
-    "react-navigation": "^5.0.0"
+    "react-navigation": "^5.0.0",
+    "zustand": "^5.0.7"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/api/kakaoLogin.ts
+++ b/src/api/kakaoLogin.ts
@@ -2,7 +2,7 @@ import * as WebBrowser from 'expo-web-browser';
 import * as Linking from 'expo-linking';
 import axios from 'axios';
 import { TokenResponse } from '../types/kakao';
-import { saveTokens } from '../utils/tokenStorage';
+import { saveTokens, saveRoles } from '../utils/tokenStorage';
 
 const KAKAO_LOGIN_URL = process.env.EXPO_PUBLIC_KAKAO_LOGIN_URL;
 if (!KAKAO_LOGIN_URL) throw new Error('[KakaoLogin] EXPO_PUBLIC_KAKAO_LOGIN_URL is not defined.');
@@ -13,14 +13,13 @@ function timeout(ms: number): Promise<never> {
   });
 }
 
-const handleKakaoLogin = async (): Promise<TokenResponse | null> => {
+const handleKakaoLogin = async (): Promise<(TokenResponse & { roles: string[] }) | null> => {
   try {
     const redirectUrl = Linking.createURL('oauth');
     const loginUrl = `${KAKAO_LOGIN_URL}?redirect_uri=${encodeURIComponent(redirectUrl)}&mobile=true`;
 
     const timeoutPromise = timeout(60000);
 
-    // 카카오 로그인 창 열기
     const result = (await Promise.race([
       WebBrowser.openAuthSessionAsync(loginUrl, redirectUrl, { showInRecents: true }),
       timeoutPromise,
@@ -28,29 +27,32 @@ const handleKakaoLogin = async (): Promise<TokenResponse | null> => {
 
     if (result.type !== 'success' || !result.url) return null;
 
-    // 딥링크에서 코드 추출
     const url = new URL(result.url);
     const exchangeCode = url.searchParams.get('code');
     if (!exchangeCode) return null;
 
-    // 교환 코드로 토큰 발급 요청
     const response = await axios.post(
       `${process.env.EXPO_PUBLIC_BASE_URL}/v1/users/exchange?code=${encodeURIComponent(exchangeCode)}`,
       null,
       { headers: { 'Content-Type': 'application/json' } },
     );
 
-    const { accessToken, refreshToken, id, email, newUser } = response.data.result ?? {};
+    const { id, email, newUser, roles, tokenResponseDto } = response.data.result ?? {};
 
-    if (!accessToken || !refreshToken) return null;
+    if (!tokenResponseDto?.accessToken || !tokenResponseDto?.refreshToken) return null;
 
-    await saveTokens(accessToken, refreshToken);
+    // 토큰 저장
+    await saveTokens(tokenResponseDto.accessToken, tokenResponseDto.refreshToken);
+
+    // roles 저장
+    await saveRoles(roles ?? []);
 
     return {
       id: id ?? 0,
-      tokenResponseDto: { accessToken, refreshToken },
+      tokenResponseDto,
       email: email ?? '',
       newUser: newUser ?? false,
+      roles: roles ?? [],
     };
   } catch (error) {
     if (error instanceof Error) {

--- a/src/api/kakaoLogin.ts
+++ b/src/api/kakaoLogin.ts
@@ -3,6 +3,7 @@ import * as Linking from 'expo-linking';
 import axios from 'axios';
 import { TokenResponse } from '../types/kakao';
 import { saveTokens, saveRoles } from '../utils/tokenStorage';
+import useAuthStore from '../store/useAuthStore';
 
 const KAKAO_LOGIN_URL = process.env.EXPO_PUBLIC_KAKAO_LOGIN_URL;
 if (!KAKAO_LOGIN_URL) throw new Error('[KakaoLogin] EXPO_PUBLIC_KAKAO_LOGIN_URL is not defined.');
@@ -46,6 +47,8 @@ const handleKakaoLogin = async (): Promise<(TokenResponse & { roles: string[] })
 
     // roles 저장
     await saveRoles(roles ?? []);
+
+    useAuthStore.getState().setRoles(roles ?? []);
 
     return {
       id: id ?? 0,

--- a/src/api/kakaoLogin.ts
+++ b/src/api/kakaoLogin.ts
@@ -1,9 +1,10 @@
 import * as WebBrowser from 'expo-web-browser';
 import * as Linking from 'expo-linking';
 import axios from 'axios';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { TokenResponse } from '../types/kakao';
-import { saveTokens, saveRoles } from '../utils/tokenStorage';
 import useAuthStore from '../store/useAuthStore';
+import { saveTokens } from '../utils/tokenStorage';
 
 const KAKAO_LOGIN_URL = process.env.EXPO_PUBLIC_KAKAO_LOGIN_URL;
 if (!KAKAO_LOGIN_URL) throw new Error('[KakaoLogin] EXPO_PUBLIC_KAKAO_LOGIN_URL is not defined.');
@@ -46,9 +47,9 @@ const handleKakaoLogin = async (): Promise<(TokenResponse & { roles: string[] })
     await saveTokens(tokenResponseDto.accessToken, tokenResponseDto.refreshToken);
 
     // roles 저장
-    await saveRoles(roles ?? []);
-
-    useAuthStore.getState().setRoles(roles ?? []);
+    const rolesFromBackend = roles ?? [];
+    await AsyncStorage.removeItem('roles'); // 기존 값 삭제
+    useAuthStore.getState().setRoles(rolesFromBackend);
 
     return {
       id: id ?? 0,

--- a/src/screens/auth/LoginChoiceScreen.tsx
+++ b/src/screens/auth/LoginChoiceScreen.tsx
@@ -60,6 +60,7 @@ export default function LoginChoiceScreen() {
 
   const handleKakaoLoginPress = async () => {
     const result = await handleKakaoLogin();
+    console.log('💡 로그인 직후 result:', result);
     if (result !== null) {
       // ['auth', 'accessToken']을 invalidate 하면 useAuth()의 값이 바뀌면서 protected route로 메인 화면으로 이동하게 됨
       // noinspection ES6MissingAwait

--- a/src/screens/mypage/MyPageScreen.tsx
+++ b/src/screens/mypage/MyPageScreen.tsx
@@ -99,10 +99,7 @@ export default function MyPageScreen() {
 
         <Section title="계정 관리">
           <SectionLabel label="비밀번호 재설정" onClick={() => {}} />
-          <SectionLabel
-            label="사장님 로그인 (회원가입)"
-            onClick={() => router.push('/owner/Dashboard')}
-          />
+          <SectionLabel label="사장님 계정 전환" onClick={() => router.push('/owner/Dashboard')} />
           <SectionLabel label="로그아웃" onClick={handleLogout} />
         </Section>
       </View>

--- a/src/screens/mypage/MyPageScreen.tsx
+++ b/src/screens/mypage/MyPageScreen.tsx
@@ -6,6 +6,7 @@ import Header from '../../design/component/Header';
 import colors from '../../design/colors';
 import ChevronRightIcon from '../../assets/images/chevron-right.svg';
 import logout from '../../api/logout';
+import useAuthStore from '../../store/useAuthStore';
 
 const styles = StyleSheet.create({
   container: {
@@ -70,11 +71,16 @@ export default function MyPageScreen() {
   const queryClient = useQueryClient();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 
+  // 전역 roles 읽기
+  const roles = useAuthStore((state) => state.roles);
+  const clearRoles = useAuthStore((state) => state.clearRoles);
+
   const handleLogout = async () => {
     if (isLoggingOut) return;
     setIsLoggingOut(true);
     try {
       await logout();
+      clearRoles();
       await queryClient.invalidateQueries({ queryKey: ['auth'] });
       router.replace('/auth/LoginChoiceScreen');
     } catch (error) {
@@ -99,7 +105,13 @@ export default function MyPageScreen() {
 
         <Section title="계정 관리">
           <SectionLabel label="비밀번호 재설정" onClick={() => {}} />
-          <SectionLabel label="사장님 계정 전환" onClick={() => router.push('/owner/Dashboard')} />
+          {/* ROLE_OWNER인 경우에만 노출 */}
+          {roles.includes('ROLE_OWNER') && (
+            <SectionLabel
+              label="사장님 계정 전환"
+              onClick={() => router.push('/owner/Dashboard')}
+            />
+          )}
           <SectionLabel label="로그아웃" onClick={handleLogout} />
         </Section>
       </View>

--- a/src/screens/mypage/MyPageScreen.tsx
+++ b/src/screens/mypage/MyPageScreen.tsx
@@ -6,7 +6,6 @@ import Header from '../../design/component/Header';
 import colors from '../../design/colors';
 import ChevronRightIcon from '../../assets/images/chevron-right.svg';
 import logout from '../../api/logout';
-import useAuthStore from '../../store/useAuthStore';
 
 const styles = StyleSheet.create({
   container: {
@@ -71,16 +70,11 @@ export default function MyPageScreen() {
   const queryClient = useQueryClient();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 
-  // 전역 roles 읽기
-  const roles = useAuthStore((state) => state.roles);
-  const clearRoles = useAuthStore((state) => state.clearRoles);
-
   const handleLogout = async () => {
     if (isLoggingOut) return;
     setIsLoggingOut(true);
     try {
       await logout();
-      clearRoles();
       await queryClient.invalidateQueries({ queryKey: ['auth'] });
       router.replace('/auth/LoginChoiceScreen');
     } catch (error) {
@@ -105,13 +99,7 @@ export default function MyPageScreen() {
 
         <Section title="계정 관리">
           <SectionLabel label="비밀번호 재설정" onClick={() => {}} />
-          {/* ROLE_OWNER인 경우에만 노출 */}
-          {roles.includes('ROLE_OWNER') && (
-            <SectionLabel
-              label="사장님 계정 전환"
-              onClick={() => router.push('/owner/Dashboard')}
-            />
-          )}
+          <SectionLabel label="사장님 계정 전환" onClick={() => router.push('/owner/Dashboard')} />
           <SectionLabel label="로그아웃" onClick={handleLogout} />
         </Section>
       </View>

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,15 +1,37 @@
 import { create } from 'zustand';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
-interface AuthState {
+type AuthState = {
   roles: string[];
   setRoles: (roles: string[]) => void;
   clearRoles: () => void;
-}
+  loadRoles: () => Promise<void>;
+};
 
 const useAuthStore = create<AuthState>((set) => ({
   roles: [],
-  setRoles: (roles) => set({ roles }),
-  clearRoles: () => set({ roles: [] }),
+
+  // roles 저장 + AsyncStorage 동기화
+  setRoles: (roles) => {
+    set({ roles });
+    AsyncStorage.setItem('roles', JSON.stringify(roles)).catch(console.error);
+  },
+
+  // 초기화
+  clearRoles: () => {
+    set({ roles: [] });
+    AsyncStorage.removeItem('roles').catch(console.error);
+  },
+
+  // 앱 시작 시 복원
+  loadRoles: async () => {
+    try {
+      const saved = await AsyncStorage.getItem('roles');
+      if (saved) set({ roles: JSON.parse(saved) });
+    } catch (error) {
+      console.error('Failed to load roles from storage:', error);
+    }
+  },
 }));
 
 export default useAuthStore;

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -11,19 +11,18 @@ type AuthState = {
 const useAuthStore = create<AuthState>((set) => ({
   roles: [],
 
-  // roles 저장 + AsyncStorage 동기화
   setRoles: (roles) => {
     set({ roles });
-    AsyncStorage.setItem('roles', JSON.stringify(roles)).catch(console.error);
+    AsyncStorage.setItem('roles', JSON.stringify(roles))
+      .then(() => console.log('AsyncStorage에 roles 저장 완료:', roles))
+      .catch(console.error);
   },
 
-  // 초기화
   clearRoles: () => {
     set({ roles: [] });
     AsyncStorage.removeItem('roles').catch(console.error);
   },
 
-  // 앱 시작 시 복원
   loadRoles: async () => {
     try {
       const saved = await AsyncStorage.getItem('roles');

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface AuthState {
+  roles: string[];
+  setRoles: (roles: string[]) => void;
+  clearRoles: () => void;
+}
+
+const useAuthStore = create<AuthState>((set) => ({
+  roles: [],
+  setRoles: (roles) => set({ roles }),
+  clearRoles: () => set({ roles: [] }),
+}));
+
+export default useAuthStore;

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -1,16 +1,12 @@
 import * as Keychain from 'react-native-keychain';
 
-const ACCESS_TOKEN_KEY = 'com.kkukmoa.accessToken';
-const REFRESH_TOKEN_KEY = 'com.kkukmoa.refreshToken';
-const ROLES_KEY = 'com.kkukmoa.userRoles';
-
 export const saveTokens = async (accessToken: string, refreshToken: string) => {
   try {
     await Keychain.setGenericPassword('accessToken', accessToken, {
-      service: ACCESS_TOKEN_KEY,
+      service: 'com.kkukmoa.accessToken',
     });
     await Keychain.setGenericPassword('refreshToken', refreshToken, {
-      service: REFRESH_TOKEN_KEY,
+      service: 'com.kkukmoa.refreshToken',
     });
   } catch (error) {
     console.error('Failed to save tokens:', error);
@@ -20,7 +16,7 @@ export const saveTokens = async (accessToken: string, refreshToken: string) => {
 
 export const getAccessToken = async (): Promise<string | null> => {
   try {
-    const creds = await Keychain.getGenericPassword({ service: ACCESS_TOKEN_KEY });
+    const creds = await Keychain.getGenericPassword({ service: 'com.kkukmoa.accessToken' });
     return creds ? creds.password : null;
   } catch (error) {
     console.error('Failed to get access token:', error);
@@ -30,26 +26,10 @@ export const getAccessToken = async (): Promise<string | null> => {
 
 export const getRefreshToken = async (): Promise<string | null> => {
   try {
-    const creds = await Keychain.getGenericPassword({ service: REFRESH_TOKEN_KEY });
+    const creds = await Keychain.getGenericPassword({ service: 'com.kkukmoa.refreshToken' });
     return creds ? creds.password : null;
   } catch (error) {
     console.error('Failed to get refresh token:', error);
     return null;
   }
-};
-
-// Roles 저장/불러오기
-export const saveRoles = async (roles: string[]) => {
-  await Keychain.setGenericPassword(ROLES_KEY, JSON.stringify(roles), { service: ROLES_KEY });
-};
-
-export const getRoles = async (): Promise<string[] | null> => {
-  const credentials = await Keychain.getGenericPassword({ service: ROLES_KEY });
-  return credentials ? JSON.parse(credentials.password) : null;
-};
-
-export const clearAuth = async () => {
-  await Keychain.resetGenericPassword({ service: ACCESS_TOKEN_KEY });
-  await Keychain.resetGenericPassword({ service: REFRESH_TOKEN_KEY });
-  await Keychain.resetGenericPassword({ service: ROLES_KEY });
 };

--- a/src/utils/tokenStorage.ts
+++ b/src/utils/tokenStorage.ts
@@ -1,12 +1,16 @@
 import * as Keychain from 'react-native-keychain';
 
+const ACCESS_TOKEN_KEY = 'com.kkukmoa.accessToken';
+const REFRESH_TOKEN_KEY = 'com.kkukmoa.refreshToken';
+const ROLES_KEY = 'com.kkukmoa.userRoles';
+
 export const saveTokens = async (accessToken: string, refreshToken: string) => {
   try {
     await Keychain.setGenericPassword('accessToken', accessToken, {
-      service: 'com.kkukmoa.accessToken',
+      service: ACCESS_TOKEN_KEY,
     });
     await Keychain.setGenericPassword('refreshToken', refreshToken, {
-      service: 'com.kkukmoa.refreshToken',
+      service: REFRESH_TOKEN_KEY,
     });
   } catch (error) {
     console.error('Failed to save tokens:', error);
@@ -16,7 +20,7 @@ export const saveTokens = async (accessToken: string, refreshToken: string) => {
 
 export const getAccessToken = async (): Promise<string | null> => {
   try {
-    const creds = await Keychain.getGenericPassword({ service: 'com.kkukmoa.accessToken' });
+    const creds = await Keychain.getGenericPassword({ service: ACCESS_TOKEN_KEY });
     return creds ? creds.password : null;
   } catch (error) {
     console.error('Failed to get access token:', error);
@@ -26,10 +30,26 @@ export const getAccessToken = async (): Promise<string | null> => {
 
 export const getRefreshToken = async (): Promise<string | null> => {
   try {
-    const creds = await Keychain.getGenericPassword({ service: 'com.kkukmoa.refreshToken' });
+    const creds = await Keychain.getGenericPassword({ service: REFRESH_TOKEN_KEY });
     return creds ? creds.password : null;
   } catch (error) {
     console.error('Failed to get refresh token:', error);
     return null;
   }
+};
+
+// Roles 저장/불러오기
+export const saveRoles = async (roles: string[]) => {
+  await Keychain.setGenericPassword(ROLES_KEY, JSON.stringify(roles), { service: ROLES_KEY });
+};
+
+export const getRoles = async (): Promise<string[] | null> => {
+  const credentials = await Keychain.getGenericPassword({ service: ROLES_KEY });
+  return credentials ? JSON.parse(credentials.password) : null;
+};
+
+export const clearAuth = async () => {
+  await Keychain.resetGenericPassword({ service: ACCESS_TOKEN_KEY });
+  await Keychain.resetGenericPassword({ service: REFRESH_TOKEN_KEY });
+  await Keychain.resetGenericPassword({ service: ROLES_KEY });
 };


### PR DESCRIPTION
## 🔨 작업 내용
* 유저 roles 받아온 후 저장

const roles = useAuthStore((state) => state.roles);
이런 식으로 현재 저장된 roles 불러와서 사용하기

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 로그인 후 사용자 역할을 안전하게 저장하고, 앱 시작 시 자동으로 불러와 권한 상태가 지속됩니다.
- Style
  - 마이페이지 ‘사장님 로그인 (회원가입)’ 문구를 ‘사장님 계정 전환’으로 변경해 의미를 명확히 했습니다.
- Chores
  - 상태 관리용 라이브러리 의존성을 추가했습니다.
  - 로그인 흐름에 결과 로깅을 추가해 진단 가능성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->