### PR TITLE
사장님 스탬프 QR UI 구현 및 API 연동[#95]

### DIFF
--- a/app/owner/OwnerStampQR.tsx
+++ b/app/owner/OwnerStampQR.tsx
@@ -1,0 +1,3 @@
+import OwnerStampQR from '../../src/screens/owner/OwnerStampQR';
+
+export default OwnerStampQR;

--- a/src/screens/main/MainScreen.tsx
+++ b/src/screens/main/MainScreen.tsx
@@ -140,7 +140,10 @@ function MainScreen() {
             <TouchableOpacity style={styles.iconButton}>
               <QRIcon width={26} height={26} />
             </TouchableOpacity>
-            <TouchableOpacity style={styles.iconButton}>
+            <TouchableOpacity
+              style={styles.iconButton}
+              onPress={() => router.push('/stamp/StampList')}
+            >
               <StampIcon width={26} height={26} />
             </TouchableOpacity>
           </View>

--- a/src/screens/owner/Dashboard.tsx
+++ b/src/screens/owner/Dashboard.tsx
@@ -15,7 +15,7 @@ import GuideIcon from '../../assets/images/guide-icon.svg';
 
 const menuItems = [
   { id: 1, title: 'QR 스캔', icon: QrIcon, route: '/owner/VoucherPayment' },
-  { id: 2, title: '스탬프 QR코드', icon: StampIcon, route: '/stamp-qr' },
+  { id: 2, title: '스탬프 QR코드', icon: StampIcon, route: '/owner/OwnerStampQR' },
   { id: 3, title: '매장관리', icon: StoreIcon, route: '/store' },
   { id: 4, title: '가게매출', icon: DollarIcon, route: '/sales' },
   { id: 5, title: '알림설정', icon: BellIcon, route: '/alarm-settings' },

--- a/src/screens/owner/OwnerStampQR.tsx
+++ b/src/screens/owner/OwnerStampQR.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { View, Image, StyleSheet, ActivityIndicator, Text } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import apiClient from '../../api/client';
+import Header from '../../design/component/Header';
+import colors from '../../design/colors';
+
+interface StampQRResponse {
+  isSuccess: boolean;
+  code: string;
+  result: {
+    qrcode: string;
+    store_name: string;
+  };
+  message: string;
+}
+
+const fetchQRCode = async (): Promise<StampQRResponse['result']> => {
+  const { data } = await apiClient.get<StampQRResponse>('/v1/owners/qrcode/stamps');
+  if (!data.isSuccess) {
+    throw new Error(data.message || 'QR 코드 발급 실패');
+  }
+  return data.result;
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.light.white,
+    overflow: 'hidden',
+  },
+  qrWrapper: {
+    paddingTop: '50%',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  qrImage: {
+    width: 234,
+    height: 234,
+  },
+  errorText: {
+    color: colors.light.main,
+    fontSize: 16,
+  },
+});
+
+export default function OwnerStampQR() {
+  const router = useRouter();
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['stampQRCode'],
+    queryFn: fetchQRCode,
+    refetchInterval: 60000, // 1분마다 새로 요청
+    refetchOnWindowFocus: false,
+  });
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.container}>
+        <Header title={data?.store_name || '스탬프 QR'} onBackPress={() => router.back()} />
+        <View style={styles.qrWrapper}>
+          {isLoading && <ActivityIndicator size="large" color={colors.light.main} />}
+          {isError && <Text style={styles.errorText}>{(error as Error).message}</Text>}
+          {data?.qrcode && (
+            <Image
+              source={{ uri: `data:image/png;base64,${data.qrcode}` }}
+              style={styles.qrImage}
+              resizeMode="contain"
+            />
+          )}
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/src/screens/owner/OwnerStampQR.tsx
+++ b/src/screens/owner/OwnerStampQR.tsx
@@ -49,7 +49,7 @@ const styles = StyleSheet.create({
 export default function OwnerStampQR() {
   const router = useRouter();
 
-  const { data, isLoading, isError, error } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: ['stampQRCode'],
     queryFn: fetchQRCode,
     refetchInterval: 60000, // 1분마다 새로 요청
@@ -62,7 +62,9 @@ export default function OwnerStampQR() {
         <Header title={data?.store_name || '스탬프 QR'} onBackPress={() => router.back()} />
         <View style={styles.qrWrapper}>
           {isLoading && <ActivityIndicator size="large" color={colors.light.main} />}
-          {isError && <Text style={styles.errorText}>{(error as Error).message}</Text>}
+          {!!error && error instanceof Error && (
+            <Text style={styles.errorText}>{error.message}</Text>
+          )}
           {data?.qrcode && (
             <Image
               source={{ uri: `data:image/png;base64,${data.qrcode}` }}


### PR DESCRIPTION
## 작업 내용
* 사장님 스탬프 QR UI 구현 및 API 연동
* 메인 -> 스탬프 라우팅 처리

## 스크린샷
<img width="216" height="484" alt="Screenshot_1755245306" src="https://github.com/user-attachments/assets/25328b7e-5e1b-4b5e-b637-d701835c2727" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 오너용 스탬프 QR 화면 추가: 매장명 표시, 로딩/에러 처리 및 234x234 크기 QR 이미지 표시를 지원합니다.
  * 메인 화면의 스탬프 아이콘을 눌러 스탬프 목록으로 이동할 수 있습니다.
  * 오너 대시보드 메뉴의 스탬프 QR 항목이 새 오너용 QR 화면으로 연결되도록 경로가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->