### PR TITLE
가게 찜하기 [#65]

### DIFF
--- a/src/api/shop.ts
+++ b/src/api/shop.ts
@@ -1,0 +1,16 @@
+import client from './client';
+
+export const likeStore = async (storeId: string) => {
+  const response = await client.post(`/v1/stores/like/${storeId}`);
+  return response.data;
+};
+
+export const unlikeStore = async (storeId: string) => {
+  const response = await client.delete(`/v1/stores/like/${storeId}`);
+  return response.data;
+};
+
+export const getIsLiked = async (storeId: string) => {
+  const response = await client.get(`/v1/stores/like/${storeId}/me`);
+  return response.data;
+};

--- a/src/api/shop.ts
+++ b/src/api/shop.ts
@@ -12,5 +12,5 @@ export const unlikeStore = async (storeId: string) => {
 
 export const getIsLiked = async (storeId: string) => {
   const response = await client.get(`/v1/stores/like/${storeId}/me`);
-  return response.data;
+  return response.data.result;
 };

--- a/src/hooks/useLikeStore.ts
+++ b/src/hooks/useLikeStore.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { likeStore, unlikeStore } from '../api/shop';
+import useShopStore from '../store/useShopStore';
+
+function useLikeStore() {
+  const queryClient = useQueryClient();
+  const { addFavoriteShop, removeFavoriteShop, isFavoriteShop } = useShopStore();
+
+  const { mutate: like } = useMutation({
+    mutationFn: (storeId: string) => likeStore(storeId),
+    onMutate: async (storeId: string) => {
+      await queryClient.cancelQueries({ queryKey: ['isLiked', storeId] });
+      addFavoriteShop(storeId);
+    },
+    onError: (_, storeId: string) => {
+      removeFavoriteShop(storeId);
+    },
+  });
+
+  const { mutate: unlike } = useMutation({
+    mutationFn: (storeId: string) => unlikeStore(storeId),
+    onMutate: async (storeId: string) => {
+      await queryClient.cancelQueries({ queryKey: ['isLiked', storeId] });
+      removeFavoriteShop(storeId);
+    },
+    onError: (_, storeId: string) => {
+      addFavoriteShop(storeId);
+    },
+  });
+
+  const toggleLike = (storeId: string) => {
+    if (isFavoriteShop(storeId)) {
+      unlike(storeId);
+    } else {
+      like(storeId);
+    }
+  };
+
+  return { toggleLike, isFavoriteShop, addFavoriteShop, removeFavoriteShop };
+}
+
+export default useLikeStore;

--- a/src/screens/Store/StoreBottomSheet/StoreBottomSheet.tsx
+++ b/src/screens/Store/StoreBottomSheet/StoreBottomSheet.tsx
@@ -2,10 +2,9 @@ import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react'
 import { Text, View, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
 import { useRouter } from 'expo-router';
 import BottomSheet, { BottomSheetFlatList } from '@gorhom/bottom-sheet';
-import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { getStoreList, getStoreListByCategory } from '../../../api/store';
-import { likeStore, unlikeStore } from '../../../api/shop';
-import useShopStore from '../../../store/useShopStore';
+import useLikeStore from '../../../hooks/useLikeStore';
 import styles from './StoreBottomSheet.style';
 import MapPin from '../../../assets/images/mappin.svg';
 import MapButton from '../../../assets/images/mapbutton.svg';
@@ -64,37 +63,14 @@ function StoreBottomSheet({
 }: Props) {
   const sheetRef = useRef<BottomSheet>(null);
   const router = useRouter();
-  const queryClient = useQueryClient();
 
-  const { addFavoriteShop, removeFavoriteShop, isFavoriteShop } = useShopStore();
+  const { toggleLike, isFavoriteShop, addFavoriteShop } = useLikeStore();
 
   const snapPoints = useMemo(() => ['9%', '37%', '75%'], []);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [sheetIndex, setSheetIndex] = useState(1);
   const [showMapButton, setShowMapButton] = useState(false);
-
-  const { mutate: like } = useMutation({
-    mutationFn: (storeId: string) => likeStore(storeId),
-    onMutate: async (storeId: string) => {
-      await queryClient.cancelQueries({ queryKey: ['isLiked', storeId] });
-      addFavoriteShop(storeId);
-    },
-    onError: (_, storeId) => {
-      removeFavoriteShop(storeId);
-    },
-  });
-
-  const { mutate: unlike } = useMutation({
-    mutationFn: (storeId: string) => unlikeStore(storeId),
-    onMutate: async (storeId: string) => {
-      await queryClient.cancelQueries({ queryKey: ['isLiked', storeId] });
-      removeFavoriteShop(storeId);
-    },
-    onError: (_, storeId) => {
-      addFavoriteShop(storeId);
-    },
-  });
 
   // 데이터 패칭
   const {
@@ -221,14 +197,6 @@ function StoreBottomSheet({
   const handleMapButtonPress = () => {
     setShowMapButton(false);
     sheetRef.current?.snapToIndex(0);
-  };
-
-  const toggleLike = (storeId: string) => {
-    if (isFavoriteShop(storeId)) {
-      unlike(storeId);
-    } else {
-      like(storeId);
-    }
   };
 
   const onEndReached = useCallback(() => {

--- a/src/screens/Store/StoreDetailScreen/StoreDetailScreen.tsx
+++ b/src/screens/Store/StoreDetailScreen/StoreDetailScreen.tsx
@@ -88,17 +88,20 @@ function StoreDetailScreen() {
     queryKey: ['isLiked', storeId],
     queryFn: () => getIsLiked(storeId!),
     enabled: !!storeId,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+    staleTime: 0,
   });
 
   useEffect(() => {
-    if (isLikedData && storeId) {
+    if (isLikedData !== undefined && storeId) {
       if (isLikedData) {
         addFavoriteShop(storeId);
       } else {
         removeFavoriteShop(storeId);
       }
     }
-  }, [isLikedData]);
+  }, [isLikedData, storeId, addFavoriteShop, removeFavoriteShop]);
 
   // 리뷰 데이터 패칭
   const { data: previewCards } = useQuery({

--- a/src/store/useShopStore.ts
+++ b/src/store/useShopStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+
+interface ShopState {
+  favoriteShopIds: string[];
+  addFavoriteShop: (id: string) => void;
+  removeFavoriteShop: (id: string) => void;
+  setFavoriteShops: (ids: string[]) => void;
+  isFavoriteShop: (id: string) => boolean;
+}
+
+const useShopStore = create<ShopState>((set, get) => ({
+  favoriteShopIds: [],
+
+  addFavoriteShop: (id: string) => {
+    set((state) => ({
+      favoriteShopIds: [...state.favoriteShopIds, id],
+    }));
+  },
+
+  removeFavoriteShop: (id: string) => {
+    set((state) => ({
+      favoriteShopIds: state.favoriteShopIds.filter((shopId) => shopId !== id),
+    }));
+  },
+
+  setFavoriteShops: (ids: string[]) => {
+    set({ favoriteShopIds: ids });
+  },
+
+  isFavoriteShop: (id: string) => {
+    return get().favoriteShopIds.includes(id);
+  },
+}));
+
+export default useShopStore;

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -63,4 +63,5 @@ export type StoreCardItem = {
   distanceKm: number;
   lat: number;
   lng: number;
+  liked: boolean;
 };


### PR DESCRIPTION
## 요약
- 가게 찜하기 및 화면간 연동

## 작업 내용
- 가게 찜하기 동작
- 가게 찜하기가 화면간에 연동될 수 있도록 Store 추가

## 스크린샷
| 메인화면 | 지도 바텀싯 | 상세 |
| ----- | ----- | ----- |
| <img width="408" height="916" alt="image" src="https://github.com/user-attachments/assets/8ebb7525-774a-44f4-99ec-c2bc9fe7e81b" /> | <img width="399" height="707" alt="image" src="https://github.com/user-attachments/assets/2339ce91-f036-4c87-8b7a-7d59f6e5202c" /> | <img width="411" height="909" alt="image" src="https://github.com/user-attachments/assets/a203f7fc-97cf-421d-844f-295fd1ba5c8b" /> |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 상점 좋아요/즐겨찾기 기능 추가: 메인, 바텀시트, 상세 화면에서 상태 표시 및 즉시 토글 가능
  - 서버와 좋아요 상태 자동 동기화 및 초기 ‘liked’ 값 반영
  - 낙관적 업데이트 적용으로 끊김 없는 인터랙션 제공

- Refactor
  - 좋아요 상태 관리를 전역으로 통합하여 화면 간 일관성 향상 및 중복 로직 제거
  - 초기 데이터 로드시 백엔드의 좋아요 상태를 자동으로 전역 상태에 반영

<!-- end of auto-generated comment: release notes by coderabbit.ai -->