### PR TITLE
가로모드 스크롤 수정 [#116]

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TabList, Tabs, TabSlot, TabTrigger } from 'expo-router/ui';
-import { StatusBar, StyleSheet, TouchableOpacity, View, Dimensions } from 'react-native';
+import { StatusBar, StyleSheet, TouchableOpacity, View, useWindowDimensions } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router, usePathname } from 'expo-router';
@@ -56,7 +56,7 @@ export default function Layout() {
   const insets = useSafeAreaInsets();
   const isStoreTab = pathname === '/stores' || pathname === '/';
 
-  const { width, height } = Dimensions.get('window');
+  const { width, height } = useWindowDimensions();
   const isLandscape = width > height;
 
   return (

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TabList, Tabs, TabSlot, TabTrigger } from 'expo-router/ui';
-import { StatusBar, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StatusBar, StyleSheet, TouchableOpacity, View, Dimensions } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router, usePathname } from 'expo-router';
@@ -56,6 +56,9 @@ export default function Layout() {
   const insets = useSafeAreaInsets();
   const isStoreTab = pathname === '/stores' || pathname === '/';
 
+  const { width, height } = Dimensions.get('window');
+  const isLandscape = width > height;
+
   return (
     <SafeAreaView
       edges={['left', 'right', 'bottom']}
@@ -63,8 +66,9 @@ export default function Layout() {
         flex: 1,
         paddingTop: isStoreTab ? 0 : insets.top,
         paddingBottom: insets.bottom,
-        paddingLeft: insets.left,
-        paddingRight: insets.right,
+        // 가로 모드에서는 좌우 패딩 제거
+        paddingLeft: isLandscape ? 0 : insets.left,
+        paddingRight: isLandscape ? 0 : insets.right,
         backgroundColor: colors.light.white,
       }}
     >

--- a/src/screens/GiftCard/GiftCardList.tsx
+++ b/src/screens/GiftCard/GiftCardList.tsx
@@ -31,13 +31,13 @@ const styles = StyleSheet.create({
     gap: 20,
   },
   card: {
-    width: 162,
+    width: 163,
     height: 139,
     marginTop: 10,
     alignItems: 'center',
   },
   cardImage: {
-    width: 165,
+    width: '100%',
     height: 99,
     aspectRatio: 16 / 9,
     resizeMode: 'contain',

--- a/src/screens/GiftCard/GiftCardList.tsx
+++ b/src/screens/GiftCard/GiftCardList.tsx
@@ -24,15 +24,16 @@ const styles = StyleSheet.create({
     zIndex: 10,
   },
   gridContainer: {
+    marginTop: 30,
     flexDirection: 'row',
     flexWrap: 'wrap',
-    justifyContent: 'space-between',
-    paddingHorizontal: 17,
-    paddingTop: 22,
+    justifyContent: 'center',
+    gap: 20,
   },
   card: {
-    flexBasis: '48%',
-    marginBottom: 24,
+    width: 162,
+    height: 139,
+    marginTop: 10,
     alignItems: 'center',
   },
   cardImage: {
@@ -45,7 +46,6 @@ const styles = StyleSheet.create({
     width: '100%',
     paddingHorizontal: 10,
     marginTop: 8,
-    alignItems: 'center',
   },
   cardTitle: {
     fontFamily: 'Pretendard-Bold',

--- a/src/screens/GiftCard/GiftCardPurchase.tsx
+++ b/src/screens/GiftCard/GiftCardPurchase.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, Image, Alert } from 'react-native';
+import { View, Text, TouchableOpacity, Image, Alert, ScrollView } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -85,7 +85,11 @@ export default function GiftCardPurchase() {
       <View style={styles.container}>
         <Header title="결제하기" onBackPress={() => router.back()} />
 
-        <View style={styles.content}>
+        <ScrollView
+          style={styles.content}
+          contentContainerStyle={{ paddingBottom: 120 }}
+          showsVerticalScrollIndicator={false}
+        >
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>구매상품</Text>
             <View style={styles.productBox}>
@@ -114,7 +118,7 @@ export default function GiftCardPurchase() {
               </TouchableOpacity>
             </View>
           </View>
-        </View>
+        </ScrollView>
 
         <View style={styles.footer}>
           <View style={styles.agreementRow}>

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -86,7 +86,6 @@ const useAuthStore = create<AuthState>((set, get) => ({
 
       const accessToken = await getAccessToken();
       const refreshToken = await getRefreshToken();
-      console.log('Loaded tokens:', { accessToken, refreshToken });
 
       const isAuthenticated = !!(accessToken && refreshToken && savedLoginType);
 


### PR DESCRIPTION
## 📌 PR 제목
가로 모드  스크롤 수정

## ✅ PR 개요
구매 상세 페이지 스크롤뷰 추가
_layout.tsx에서 가로모드 시 보이는 여백 제거
금액권 리스트 가로모드 시 깨지던 리스트 정렬 수정
토큰 찍어내는 콘솔 로그 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 없음
- 스타일
  - 가로 모드에서 좌우 여백을 제거해 화면 활용도를 개선했습니다.
  - 기프트카드 목록을 중앙 정렬된 고정 크기 카드 그리드로 개편하고 간격을 조정했습니다.
  - 기프트카드 구매 화면을 세로로 스크롤 가능하게 하고 하단 여유 공간을 추가했습니다.
- 작업
  - 불필요한 디버그 로그를 제거해 콘솔 노이즈를 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->