### PR TITLE
메인 화면에서 중복으로 적용된 윈도우 인셋 제거

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TabList, Tabs, TabSlot, TabTrigger } from 'expo-router/ui';
 import { StatusBar, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router, usePathname } from 'expo-router';
 import CouponsIcon from '../../src/assets/images/credit-card.svg';
 import HomeIcon from '../../src/assets/images/home.svg';
@@ -57,8 +57,7 @@ export default function Layout() {
   const isStoreTab = pathname === '/stores' || pathname === '/';
 
   return (
-    <SafeAreaView
-      edges={['left', 'right', 'bottom']}
+    <View
       style={{
         flex: 1,
         paddingTop: isStoreTab ? 0 : insets.top,
@@ -114,6 +113,6 @@ export default function Layout() {
           })}
         </TabList>
       </Tabs>
-    </SafeAreaView>
+    </View>
   );
 }


### PR DESCRIPTION
## 요약
인셋이 두 번 적용되는 문제 수정

## 스크린샷
| AS-IS | TO-BE |
| --- | --- |
| <img width="422" height="918" alt="image" src="https://github.com/user-attachments/assets/2161d3df-c789-40c7-84b5-410e9c9123fd" /> | <img width="433" height="913" alt="image" src="https://github.com/user-attachments/assets/c7a87521-8b42-4229-82de-6bf3969d23cc" /> |

## 기타
플레이스토어에 올라간 버전은 제가 로컬에서 임의로 수정해서 들어가고 있었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - SafeAreaView를 일반 View로 교체하고, 인셋 기반 패딩 적용은 그대로 유지했습니다.
  - 상단 패딩은 인셋 값에 따라 동적으로 적용되며, 하단/좌/우 패딩도 지속적으로 반영됩니다.
  - 탭 화면 전반의 레이아웃 구조는 동일하게 유지됩니다.
  - 사용자 관점에서 기능 변화는 없고, 화면 요소의 배치와 스크롤 동작은 기존과 동일하게 보입니다.
  - 다양한 기기에서 가장자리 안전 영역 처리가 일관되게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->