### PR TITLE
탭의 그림자 위치 수정

### DIFF
--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
   <color name="colorPrimary">#023c69</color>
   <color name="colorPrimaryDark">#FF8246</color>
   <color name="iconBackground">#FFFFFF</color>
+  <color name="navigationBarColor">#ffffff</color>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -3,6 +3,8 @@
     <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="android:statusBarColor">#FF8246</item>
+    <item name="android:windowLightNavigationBar">true</item>
+    <item name="android:navigationBarColor">@color/navigationBarColor</item>
     <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
   </style>
   <style name="Theme.App.SplashScreen" parent="Theme.SplashScreen">

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,11 +1,10 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-  <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+  <style name="AppTheme" parent="Theme.EdgeToEdge">
     <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="android:statusBarColor">#FF8246</item>
     <item name="android:windowLightNavigationBar">true</item>
     <item name="android:navigationBarColor">@color/navigationBarColor</item>
-    <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>
   </style>
   <style name="Theme.App.SplashScreen" parent="Theme.SplashScreen">
     <item name="windowSplashScreenBackground">@color/splashscreen_background</item>

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -56,4 +56,4 @@ EX_DEV_CLIENT_NETWORK_INSPECTOR=true
 expo.useLegacyPackaging=false
 
 # Whether the app is configured to use edge-to-edge via the app config or `react-native-edge-to-edge` plugin
-expo.edgeToEdgeEnabled=false
+expo.edgeToEdgeEnabled=true

--- a/app.json
+++ b/app.json
@@ -16,6 +16,7 @@
         "foregroundImage": "./assets/images/icon.png",
         "backgroundColor": "#FFFFFF"
       },
+      "edgeToEdgeEnabled": true,
       "intentFilters": [
         {
           "action": "VIEW",

--- a/app.json
+++ b/app.json
@@ -6,6 +6,10 @@
     "scheme": "kkukmoa",
     "icon": "./assets/images/icon.png",
     "newArchEnabled": true,
+    "androidNavigationBar": {
+      "backgroundColor": "#ffffff",
+      "barStyle": "dark-content"
+    },
     "android": {
       "package": "com.kkukmoa",
       "adaptiveIcon": {

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -24,13 +24,17 @@ const styles = StyleSheet.create({
     padding: 12,
     marginTop: 8,
   },
-  topFadeOverlay: {
+  contentContainer: {
+    flex: 1,
+    position: 'relative',
+  },
+  bottomFadeOverlay: {
     position: 'absolute',
     left: 0,
     right: 0,
     height: 50,
     zIndex: 1,
-    bottom: 80,
+    bottom: 0,
   },
 });
 
@@ -72,14 +76,17 @@ export default function Layout() {
       }}
     >
       <StatusBar barStyle="dark-content" />
-      <LinearGradient
-        start={{ x: 0, y: 1 }}
-        end={{ x: 0, y: 0 }}
-        colors={['rgba(108, 49, 49, 0.08)', 'rgba(0,0,0,0)']}
-        style={[styles.topFadeOverlay]}
-      />
       <Tabs>
-        <TabSlot />
+        <View style={styles.contentContainer}>
+          <TabSlot />
+          <LinearGradient
+            start={{ x: 0, y: 1 }}
+            end={{ x: 0, y: 0 }}
+            colors={['rgba(108, 49, 49, 0.08)', 'rgba(0,0,0,0)']}
+            style={styles.bottomFadeOverlay}
+            pointerEvents="none"
+          />
+        </View>
         <TabList style={styles.tabLayout}>
           {tabs.map((tab) => {
             // 이 페이지는 하단 탭 바가 보이지 않아야 하므로 router.push를 사용해 별도로 이동 처리함


### PR DESCRIPTION
## 요약
탭의 그림자 위치 수정

## 스크린샷
| AS-IS | TO-BE |
| --- | --- |
| <img width="695" height="179" alt="image" src="https://github.com/user-attachments/assets/fbead3f1-6a14-470a-b566-da97148b3524" /> |  <img width="412" height="105" alt="image" src="https://github.com/user-attachments/assets/348a3b68-b4e0-47ef-ae5b-68669f076e55" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - Android에서 엣지-투-엣지 레이아웃을 활성화해 더 넓은 화면 영역을 제공합니다.
  - 내비게이션 바 배경을 흰색, 아이콘/텍스트를 어두운 스타일로 적용합니다.

- 스타일
  - 화면 하단에 페이드 오버레이를 추가하고 상단 페이드를 제거해 스크롤 종료부 가독성을 개선했습니다.
  - 탭 화면 레이아웃을 조정해 콘텐츠와 페이드의 정렬과 레이어링을 개선했습니다.

- 설정
  - 앱 설정에 Android 내비게이션 바 색상/스타일 및 엣지-투-엣지 옵션을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->